### PR TITLE
Release 4.7.8

### DIFF
--- a/js/qmn_quiz.js
+++ b/js/qmn_quiz.js
@@ -51,8 +51,8 @@ function qmnValidation( element, quiz_form_id ) {
 					result = false;
 				}
 			}
-			if ( window.sessionStorage.getItem( 'mlw_time_quiz' + quiz_id ) === null ||
-			window.sessionStorage.getItem( 'mlw_time_quiz'+quiz_id ) > 0.08 ) {
+			if ( window.localStorage.getItem( 'mlw_time_quiz' + quiz_id ) === null ||
+			window.localStorage.getItem( 'mlw_time_quiz'+quiz_id ) > 0.08 ) {
 
 				if( jQuery( this ).attr( 'class' ).indexOf( 'mlwRequiredNumber' ) > -1 && this.value === "" && +this.value != NaN ) {
 					qmnDisplayError( number_error, jQuery( this ), quiz_form_id );
@@ -192,9 +192,9 @@ function qmnActivateTimer( quiz_id ) {
 	jQuery( '#quizForm' + quiz_id + ' .mlw_qmn_timer').show();
 	qmn_timer_activated = true;
 	var minutes = 0;
-	if ( window.sessionStorage.getItem( 'mlw_started_quiz' + quiz_id ) == "yes" &&
-	window.sessionStorage.getItem( 'mlw_time_quiz' + quiz_id ) >= 0 ) {
-		minutes = window.sessionStorage.getItem( 'mlw_time_quiz' + quiz_id );
+	if ( window.localStorage.getItem( 'mlw_started_quiz' + quiz_id ) == "yes" &&
+	window.localStorage.getItem( 'mlw_time_quiz' + quiz_id ) >= 0 ) {
+		minutes = window.localStorage.getItem( 'mlw_time_quiz' + quiz_id );
 	} else {
 		minutes = qmn_quiz_data[quiz_id].timer_limit;
 	}
@@ -209,8 +209,8 @@ function qmnTimer( quiz_id ) {
 	if (window.amount < 0) {
 		window.amount = 0;
 	}
-	window.sessionStorage.setItem( 'mlw_time_quiz' + quiz_id, window.amount / 60 );
-	window.sessionStorage.setItem( 'mlw_started_quiz' + quiz_id, "yes" );
+	window.localStorage.setItem( 'mlw_time_quiz' + quiz_id, window.amount / 60 );
+	window.localStorage.setItem( 'mlw_started_quiz' + quiz_id, "yes" );
 	jQuery( '#quizForm' + quiz_id + ' .mlw_qmn_timer').html( qmnMinToSec( window.amount ) );
 	window.document.title = qmnMinToSec( window.amount ) + " " + qsmTitleText;
 	if ( window.amount <= 0 ) {
@@ -228,8 +228,8 @@ function qmnTimer( quiz_id ) {
 }
 
 function qmnEndTimer( quiz_id ) {
-	window.sessionStorage.setItem('mlw_time_quiz' + quiz_id, 'completed');
-	window.sessionStorage.setItem('mlw_started_quiz' + quiz_id, 'no');
+	window.localStorage.setItem('mlw_time_quiz' + quiz_id, 'completed');
+	window.localStorage.setItem('mlw_started_quiz' + quiz_id, 'no');
 	window.document.title = qsmTitleText;
 	if ( typeof window.qsmCounter != 'undefined' ) {
 		clearInterval( window.qsmCounter );

--- a/mlw_quizmaster2.php
+++ b/mlw_quizmaster2.php
@@ -2,7 +2,7 @@
 /**
 * Plugin Name: Quiz And Survey Master
 * Description: Easily and quickly add quizzes and surveys to your website.
-* Version: 4.7.7
+* Version: 4.7.8
 * Author: Frank Corso
 * Author URI: http://www.quizandsurveymaster.com/
 * Plugin URI: http://www.quizandsurveymaster.com/
@@ -10,7 +10,7 @@
 * Domain Path: /languages
 *
 * @author Frank Corso
-* @version 4.7.7
+* @version 4.7.8
 */
 if ( ! defined( 'ABSPATH' ) ) exit;
 
@@ -30,7 +30,7 @@ class MLWQuizMasterNext
 	 * @var string
 	 * @since 4.0.0
 	 */
-	public $version = '4.7.7';
+	public $version = '4.7.8';
 
 	/**
 	 * QMN Alert Manager Object

--- a/php/about-page.php
+++ b/php/about-page.php
@@ -48,7 +48,7 @@ function mlw_generate_about_page()
 		</div>
 		<div id="mlw_quiz_changelog" class="qmn_tab" style="display: none;">
 			<h2>Changelog</h2>
-			<?php QSM_Changelog_Generator::get_changelog_list( 'fpcorso/quiz_master_next', 28 ); ?>
+			<?php QSM_Changelog_Generator::get_changelog_list( 'fpcorso/quiz_master_next', 29 ); ?>
 		</div>
 		<div id="qmn_contributors" class="qmn_tab" style="display:none;">
 			<h2>GitHub Contributors</h2>

--- a/php/admin-results-page.php
+++ b/php/admin-results-page.php
@@ -75,8 +75,8 @@ function mlw_generate_quiz_results()
 	$order_by_sql = 'ORDER BY result_id DESC';
 	if ( isset( $_GET["qmn_search_phrase"] ) && !empty( $_GET["qmn_search_phrase"] ) ) {
 		$search_phrase = $_GET["qmn_search_phrase"];
-		$mlw_qmn_results_count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(result_id) FROM " . $wpdb->prefix . "mlw_results WHERE deleted='0' AND (quiz_name LIKE %s OR name LIKE %s)", '%' . $wpdb->esc_like($search_phrase) . '%', '%' . $wpdb->esc_like($search_phrase) . '%' ) );
-		$search_phrase_sql = " AND (quiz_name LIKE '%$search_phrase%' OR name LIKE '%$search_phrase%')";
+		$mlw_qmn_results_count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(result_id) FROM {$wpdb->prefix}mlw_results WHERE deleted='0' AND (quiz_name LIKE %s OR name LIKE %s OR business LIKE %s OR email LIKE %s OR phone LIKE %s)", '%' . $wpdb->esc_like($search_phrase) . '%', '%' . $wpdb->esc_like($search_phrase) . '%', '%' . $wpdb->esc_like($search_phrase) . '%', '%' . $wpdb->esc_like($search_phrase) . '%', '%' . $wpdb->esc_like($search_phrase) . '%' ) );
+		$search_phrase_sql = " AND (quiz_name LIKE '%$search_phrase%' OR name LIKE '%$search_phrase%' OR business LIKE '%$search_phrase%' OR email LIKE '%$search_phrase%' OR phone LIKE '%$search_phrase%')";
 	} else {
 		$mlw_qmn_results_count = $wpdb->get_var( "SELECT COUNT(result_id) FROM " . $wpdb->prefix . "mlw_results WHERE deleted='0'" );
 	}

--- a/php/class-qmn-quiz-manager.php
+++ b/php/class-qmn-quiz-manager.php
@@ -404,9 +404,10 @@ class QMNQuizManager
 				$question_display .= "<textarea cols='70' rows='5' class='mlw_qmn_question_comment' id='mlwComment".$mlw_question->question_id."' name='mlwComment".$mlw_question->question_id."' onclick='qmnClearField(this)'>".htmlspecialchars_decode($qmn_quiz_options->comment_field_text, ENT_QUOTES)."</textarea>";
 				$question_display .= "<br />";
 			}
-			if ($mlw_question->hints != "")
-			{
-				$question_display .= "<span title=\"".htmlspecialchars_decode($mlw_question->hints, ENT_QUOTES)."\" class='mlw_qmn_hint_link'>".__('Hint', 'quiz-master-next')."</span>";
+
+			// Checks if a hint is entered
+			if ( ! empty( $mlw_question->hints ) ) {
+				$question_display .= "<span title=\"" . esc_attr( htmlspecialchars_decode( $mlw_question->hints, ENT_QUOTES ) ) . "\" class='qsm_hint mlw_qmn_hint_link'>" . __( 'Hint', 'quiz-master-next' ) . "</span>";
 				$question_display .= "<br /><br />";
 			}
 			$question_display .= "</div>";

--- a/php/class-qmn-review-message.php
+++ b/php/class-qmn-review-message.php
@@ -95,7 +95,7 @@ class QMN_Review_Message {
 			$this->trigger,
 			'<br /><strong><em>~ Frank Corso</em></strong><br /><br />'
 		);
-		echo '&nbsp;<a target="_blank" href="https://wordpress.org/support/view/plugin-reviews/quiz-master-next?rate=5#postform" class="button-primary">' . __( 'Yeah, you deserve it!', 'quiz-master-next' ) . '</a>';
+		echo '&nbsp;<a target="_blank" href="https://wordpress.org/support/plugin/quiz-master-next/reviews/#new-topic-0" class="button-primary">' . __( 'Yeah, you deserve it!', 'quiz-master-next' ) . '</a>';
 		echo '&nbsp;<a href="' . esc_url( $already_url ) . '" class="button-secondary">' . __( 'I already did!', 'quiz-master-next' ) . '</a>';
   		echo '&nbsp;<a href="' . esc_url( $nope_url ) . '" class="button-secondary">' . __( 'No, this plugin is not good enough', 'quiz-master-next' ) . '</a>';
 		echo "<br /><br /></div>";
@@ -116,6 +116,8 @@ class QMN_Review_Message {
 				$update_trigger = 100;
 			} else if ( $this->trigger === 100 ) {
 				$update_trigger = 1000;
+			} else if ( $this->trigger === 1000 ) {
+				$update_trigger = -1;
 			}
 			update_option( 'qmn_review_message_trigger', $update_trigger );
 		}

--- a/php/options-page-questions-tab.php
+++ b/php/options-page-questions-tab.php
@@ -76,7 +76,7 @@ function mlw_options_questions_tab_content()
 		$mlw_edit_question_id = intval( $_POST["question_id"] );
 		$mlw_edit_question_type = sanitize_text_field( $_POST["question_type"] );
 		$edit_comments = htmlspecialchars( $_POST["comments"], ENT_QUOTES );
-		$edit_hint = htmlspecialchars( $_POST["hint"], ENT_QUOTES );
+		$edit_hint = htmlspecialchars( stripslashes( $_POST["hint"] ), ENT_QUOTES );
 		$edit_question_order = intval( $_POST["new_question_order"] );
 		$total_answers = intval( $_POST["new_question_answer_total"] );
 
@@ -278,7 +278,7 @@ function mlw_options_questions_tab_content()
 		$question_answer_info = htmlspecialchars( stripslashes( $_POST["correct_answer_info"] ), ENT_QUOTES );
 		$question_type = sanitize_text_field( $_POST["question_type"] );
 		$comments = htmlspecialchars( $_POST["comments"], ENT_QUOTES );
-		$hint = htmlspecialchars( $_POST["hint"], ENT_QUOTES );
+		$hint = htmlspecialchars( stripslashes( $_POST["hint"] ), ENT_QUOTES );
 		$new_question_order = intval( $_POST["new_question_order"] );
 		$total_answers = intval( $_POST["new_question_answer_total"] );
 

--- a/php/quiz-options-page.php
+++ b/php/quiz-options-page.php
@@ -16,7 +16,7 @@ function mlw_generate_quiz_options()
 	global $wpdb;
 	global $mlwQuizMasterNext;
 	$tab_array = $mlwQuizMasterNext->pluginHelper->get_settings_tabs();
-	$active_tab = isset( $_GET[ 'tab' ] ) ? $_GET[ 'tab' ] : 'questions';
+	$active_tab = isset( $_GET[ 'tab' ] ) ? stripslashes( $_GET[ 'tab' ] ) : 'questions';
 	$quiz_id = intval($_GET["quiz_id"]);
 	if (isset($_GET["quiz_id"]))
 	{

--- a/readme.txt
+++ b/readme.txt
@@ -110,7 +110,11 @@ This is usually a theme conflict. You can [checkout out our common conflict solu
 == Changelog ==
 
 = 4.7.8 (November, 2, 2016) =
-  * 
+  * Closed Bug: Apostrophe in translation for tab name text causing errors - Issue #490
+  * Closed Bug: Timer resets if user copies link, opens new tab, and pastes link - Issue #489
+  * Closed Enhancement: Add Business, Email, And Phone To Quiz Results Search - Issue #485
+  * Closed Bug: "You Deserve It" button in review message leads to 404 - Issue #476
+  * Closed Bug: In the Hint dropdown text, the 'apostrophe' does not display properly - Issue #453
 
 = 4.7.7 (September 10, 2016) =
   * Closed Bug: From Email Bug Causing 500 Error On WP 4.6 - Issue #473

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://mylocalwebstop.com/downloads/donation-service-payment/
 Tags: quiz, survey, test, score, exam, questionnaire, email, answer, question, certificate, points, results
 Requires at least: 4.1
 Tested up to: 4.6.1
-Stable tag: 4.7.7
+Stable tag: 4.7.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -109,6 +109,9 @@ This is usually a theme conflict. You can [checkout out our common conflict solu
 
 == Changelog ==
 
+= 4.7.8 (November, 2, 2016) =
+  * 
+
 = 4.7.7 (September 10, 2016) =
   * Closed Bug: From Email Bug Causing 500 Error On WP 4.6 - Issue #473
   * Closed Enhancement: Table Styles Don't Match Default WordPress Styles. - Issue #471
@@ -125,5 +128,5 @@ This is usually a theme conflict. You can [checkout out our common conflict solu
 
 == Upgrade Notice ==
 
-= 4.7.7 =
-Upgrade to fix bug affecting some users using WordPress 4.6 causing results page not to load
+= 4.7.8 =
+Upgrade to fix bug affecting some users where the results page will not load


### PR DESCRIPTION
* Closed Bug: Apostrophe in translation for tab name text causing errors - Issue #490
* Closed Bug: Timer resets if user copies link, opens new tab, and pastes link - Issue #489
* Closed Enhancement: Add Business, Email, And Phone To Quiz Results Search - Issue #485
* Closed Bug: "You Deserve It" button in review message leads to 404 - Issue #476
* Closed Bug: In the Hint dropdown text, the 'apostrophe' does not display properly - Issue #453