### PR TITLE
Release 5.0

### DIFF
--- a/css/qsm-admin.css
+++ b/css/qsm-admin.css
@@ -127,6 +127,22 @@ div.qsm_icon_wrap {
   border-radius: 20px;
 }
 
+.qsm-tab-content .feature {
+  margin-bottom: 20px;
+}
+
+.qsm-tab-content .feature .feature-headline {
+  margin: 1.1em 0 .2em;
+  font-size: 2.4em;
+  font-weight: 300;
+  line-height: 1.3;
+  text-align: center;
+}
+
+.qsm-tab-content .feature .feature-text {
+  text-align: center;
+}
+
 ul.changelog {
   background-color: #fff;
   padding: 10px 10px;

--- a/css/qsm-admin.css
+++ b/css/qsm-admin.css
@@ -133,7 +133,7 @@ div.qsm_icon_wrap {
 
 .qsm-tab-content .feature .feature-headline {
   margin: 1.1em 0 .2em;
-  font-size: 2.4em;
+  font-size: 40px;
   font-weight: 300;
   line-height: 1.3;
   text-align: center;
@@ -141,6 +141,7 @@ div.qsm_icon_wrap {
 
 .qsm-tab-content .feature .feature-text {
   text-align: center;
+  font-size: 16px;
 }
 
 ul.changelog {

--- a/php/about-page.php
+++ b/php/about-page.php
@@ -11,7 +11,7 @@ function mlw_generate_about_page() {
 
 	global $mlwQuizMasterNext;
 	$version = $mlwQuizMasterNext->version;
-	wp_enqueue_style( 'qsn_admin_style', plugins_url( '../css/qsm-admin.css' , __FILE__ ), array(), '5.0.0' );
+	wp_enqueue_style( 'qsm_admin_style', plugins_url( '../css/qsm-admin.css' , __FILE__ ), array(), '5.0.0' );
 	wp_enqueue_script( 'qsm_admin_js', plugins_url( '../js/admin.js' , __FILE__ ), array( 'jquery' ), '5.0.0' );
 	?>
 	<style>
@@ -32,12 +32,41 @@ function mlw_generate_about_page() {
 				<?php _e('People Who Make QSM Possible', 'quiz-master-next'); ?></a>
 		</h2>
 		<div class="qsm-tab-content tab-1">
-			<h2 style="margin: 1.1em 0 .2em;font-size: 2.4em;font-weight: 300;line-height: 1.3;text-align: center;">Notice: Certificates Are Being Moved</h2>
-			<p style="text-align: center;">The certificate feature is being moved from core to a free addon. If you use certificates, please <a target="_blank" href="http://quizandsurveymaster.com/certificate-feature-moved/?utm_source=about_page&utm_medium=plugin&utm_campaign=qsm_plugin&utm_content=certificate_removal_notice">read our post about certificates being moved.</a></p>
-			<br />
-			<h2 style="margin: 1.1em 0 .2em;font-size: 2.4em;font-weight: 300;line-height: 1.3;text-align: center;">Major Coming Changes In 5.0.0</h2>
-			<p style="text-align: center;">We have several major changes and features we are planning for version 5.0.0. To keep up with the changes and be notified when the beta becomes available. Please <a target="_blank" href="http://quizandsurveymaster.com/subscribe-to-our-newsletter/?utm_source=about_page&utm_medium=plugin&utm_campaign=qsm_plugin&utm_content=subscribe_for_beta_notices">subscribe to our newsletter</a>.</p>
-			<br />
+			<div class="feature">
+				<h2 class="feature-headline">Welcome to QSM 5.0!</h2>
+				<p class="feature-text">There are many changes in version 5.0. From a contact fields system to new developer functions, there are a lot to see.</p>
+			</div>
+			<div class="feature">
+				<h2 class="feature-headline">New Contact Fields System</h2>
+				<p class="feature-text">The biggest change is our new contact fields. Instead of having to edit some of the options on one tab, the text on another tab, and final settings on another tab, all of the contact field options are on the new "Contact"" tab.</p>
+				<p class="feature-text">Even better, you can now create new contact fields for any thing you need! Need an "Age" field or a "Attendee ID" field? Now you can!</p>
+				<p class="feature-text">You can now choose from three different contact field types: Small Open Answer, Email, or Checkbox.</p>
+			</div>
+			<div class="feature">
+				<h2 class="feature-headline">More Text Is Editable</h2>
+				<p class="feature-text">You can now edit the text for the "Hint" as well as all 4 of the error messages that are used when validating a user's responses. You can edit these on the "Text" tab.</p>
+			</div>
+			<div class="feature">
+				<h2 class="feature-headline">Scrollable And Searchable Quizzes/Surveys</h2>
+				<p class="feature-text">For the users who have many quizzes and surveys on their site, it has been difficult and frustrating to find a particular quiz/survey to edit it on the Quizzes page. Now, the quizzes/surveys can be searched using the new searchbox in the top-right! Also, there are no more pages of quizzes/surveys to look through as the quizzes/surveys load as you scroll down making editing much quicker and more efficient.</p>
+			</div>
+			<div class="feature">
+				<h2 class="feature-headline">Introduction Of Onboarding Process</h2>
+				<p class="feature-text">New users of this plugin will now see a getting started video and documentation when first accessing the Quizzes/Surveys page.</p>
+			</div>
+			<div class="feature">
+				<h2 class="feature-headline">Certificate Is Now An Addon</h2>
+				<p class="feature-text">As we stated 8 months ago, the certificate feature is no longer built into the plugin and is available as a free addon.</p>
+			</div>
+			<hr />
+			<div class="feature">
+				<h2 class="feature-headline">For Developers: New Settings System</h2>
+				<p class="feature-text">The settings system has been completely rewritten and are now stored as serialized arrays that can be extended instead of hardcoded as columns in the database. You can now "register" settings with defaults and assign which tab they belong to. Documentation coming soon.</p>
+			</div>
+			<div class="feature">
+				<h2 class="feature-headline">For Developers: New Results Page Tabs</h2>
+				<p class="feature-text">The "Results" page in the admin can now be extended with tabs. A great location for adding features that affect or analyze the results.</p>
+			</div>
 		</div>
 		<div class="qsm-tab-content tab-2" style="display: none;">
 			<h2>Changelog</h2>

--- a/php/about-page.php
+++ b/php/about-page.php
@@ -11,8 +11,8 @@ function mlw_generate_about_page() {
 
 	global $mlwQuizMasterNext;
 	$version = $mlwQuizMasterNext->version;
-	wp_enqueue_style( 'qmn_admin_style', plugins_url( '../css/qsm-admin.css' , __FILE__ ) );
-	wp_enqueue_script('qmn_admin_js', plugins_url( '../js/admin.js' , __FILE__ ), array( 'jquery' ) );
+	wp_enqueue_style( 'qsn_admin_style', plugins_url( '../css/qsm-admin.css' , __FILE__ ), array(), '5.0.0' );
+	wp_enqueue_script( 'qsm_admin_js', plugins_url( '../js/admin.js' , __FILE__ ), array( 'jquery' ), '5.0.0' );
 	?>
 	<style>
 		div.qsm_icon_wrap {

--- a/php/about-page.php
+++ b/php/about-page.php
@@ -38,8 +38,8 @@ function mlw_generate_about_page() {
 			</div>
 			<div class="feature">
 				<h2 class="feature-headline">New Contact Fields System</h2>
-				<p class="feature-text">The biggest change is our new contact fields. Instead of having to edit some of the options on one tab, the text on another tab, and final settings on another tab, all of the contact field options are on the new "Contact"" tab.</p>
-				<p class="feature-text">Even better, you can now create new contact fields for any thing you need! Need an "Age" field or a "Attendee ID" field? Now you can!</p>
+				<p class="feature-text">The biggest change is our new contact fields. Instead of having to edit some of the options on one tab, the text on another tab, and final settings on another tab, all of the contact field options are on the new "Contact" tab.</p>
+				<p class="feature-text">Even better, you can now create new contact fields for anything you need! Need an "Age" field or an "Attendee ID" field? Now you can!</p>
 				<p class="feature-text">You can now choose from three different contact field types: Small Open Answer, Email, or Checkbox.</p>
 			</div>
 			<div class="feature">
@@ -61,7 +61,7 @@ function mlw_generate_about_page() {
 			<hr />
 			<div class="feature">
 				<h2 class="feature-headline">For Developers: New Settings System</h2>
-				<p class="feature-text">The settings system has been completely rewritten and are now stored as serialized arrays that can be extended instead of hardcoded as columns in the database. You can now "register" settings with defaults and assign which tab they belong to. Documentation coming soon.</p>
+				<p class="feature-text">The settings system has been completely rewritten and is now stored as serialized arrays that can be extended instead of hardcoded as columns in the database. You can now "register" settings with defaults and assign which tab they belong to. Documentation coming soon.</p>
 			</div>
 			<div class="feature">
 				<h2 class="feature-headline">For Developers: New Results Page Tabs</h2>

--- a/php/admin-results-details-page.php
+++ b/php/admin-results-details-page.php
@@ -81,6 +81,9 @@ function qmn_generate_results_details_tab() {
 	}
 	if ( is_serialized( $mlw_results_data->quiz_results ) && is_array( @unserialize( $mlw_results_data->quiz_results ) ) ) {
 		$results = unserialize($mlw_results_data->quiz_results);
+		if ( ! isset( $results["contact"] ) ) {
+			$results["contact"] = array();
+		}
 	} else {
 		$template = str_replace( "%QUESTIONS_ANSWERS%" , $mlw_results_data->quiz_results, $template);
 		$template = str_replace( "%TIMER%" , '', $template);

--- a/php/class-qmn-quiz-manager.php
+++ b/php/class-qmn-quiz-manager.php
@@ -548,7 +548,7 @@ class QMNQuizManager {
 		$qmn_array_for_variables['user_business'] = 'None';
 		$qmn_array_for_variables['user_email'] = 'None';
 		$qmn_array_for_variables['user_phone'] = 'None';
-		$contact_responses = QSM_Contact_Manager::process_fields();
+		$contact_responses = QSM_Contact_Manager::process_fields( $qmn_quiz_options );
 		foreach ( $contact_responses as $field ) {
       if ( isset( $field['use'] ) ) {
         if ( 'name' === $field['use'] ) {

--- a/php/class-qsm-contact-manager.php
+++ b/php/class-qsm-contact-manager.php
@@ -87,6 +87,8 @@ class QSM_Contact_Manager {
 
       // Cycle through each of the contact fields
       for ( $i = 0; $i < count( $fields ); $i++ ) {
+
+        $return .= '<div class="qsm_contact_div">';
         $class = '';
         $return .= "<span class='mlw_qmn_question qsm_question'>{$fields[ $i ]['label']}</span>";
         $value = '';
@@ -123,6 +125,8 @@ class QSM_Contact_Manager {
           default:
             break;
         }
+
+        $return .= '</div>';
       }
     }
 

--- a/php/class-qsm-contact-manager.php
+++ b/php/class-qsm-contact-manager.php
@@ -141,7 +141,7 @@ class QSM_Contact_Manager {
    * @since 5.0.0
    * @return array An array of all labels and values for the contact fields
    */
-  public static function process_fields() {
+  public static function process_fields( $options ) {
 
     $responses = array();
 

--- a/php/class-qsm-settings.php
+++ b/php/class-qsm-settings.php
@@ -143,9 +143,23 @@ class QSM_Quiz_Settings {
    */
   public function get_setting( $setting, $default = false ) {
 
+    global $mlwQuizMasterNext;
+
     // Return if empty
     if ( empty( $setting ) ) {
       return false;
+    }
+
+    // Check if ID is not set, for backwards compatibility
+    if ( ! $this->quiz_id ) {
+      $quiz_id = $mlwQuizMasterNext->quizCreator->get_id();
+
+      // If get_id doesn't work, return false
+      if ( ! $quiz_id ) {
+        return false;
+      } else {
+        $this->prepare_quiz( $quiz_id );
+      }
     }
 
     // Check if setting exists

--- a/php/quizzes-page.php
+++ b/php/quizzes-page.php
@@ -54,7 +54,7 @@ function qsm_generate_quizzes_surveys_page() {
 
 	// Load quiz posts
 	$post_to_quiz_array = array();
-	$my_query = new WP_Query( array( 'post_type' => 'quiz' ) );
+	$my_query = new WP_Query( array( 'post_type' => 'quiz', 'posts_per_page' => -1, 'post_status' => 'publish' ) );
 	if ( $my_query->have_posts() ) {
 	  while ( $my_query->have_posts() ) {
 	    $my_query->the_post();

--- a/readme.txt
+++ b/readme.txt
@@ -25,7 +25,7 @@ You can easily create surveys for your users. Everything from customer satisfact
 = Different Types Of Questions =
 You can have **multiple choice** (radio buttons), **true and false**, **open answer** question, **drop down**, **multiple response** (checkboxes), **fill in the blank**, **number**, **captcha**, and **accept**. More types are being supported in future updates!
 
-= Multiple Landing Pages For Each Quiz =
+= Multiple Results Pages For Each Quiz =
 Each quiz or survey can have **unlimited** results pages that can be customized with your text. Show different results pages based on the users score!
 
 = Emails After Completion Of Quiz And Survey =
@@ -109,8 +109,23 @@ This is usually a theme conflict. You can [checkout out our common conflict solu
 
 == Changelog ==
 
-= 5.0.0 (X) =
-  *
+= 5.0.0 (March 25, 2017) =
+  * Closed: Fix delete custom post types during uninstall bug ([Issue #527](https://github.com/fpcorso/quiz_master_next/issues/527))
+  * Closed: Change Shortcode To QSM ([Issue #515](https://github.com/fpcorso/quiz_master_next/issues/515))
+  * Closed: Search function for quizzes/surveys ([Issue #492](https://github.com/fpcorso/quiz_master_next/issues/492))
+  * Closed: Create new fields class to handle creation/post data of settings fields ([Issue #450](https://github.com/fpcorso/quiz_master_next/issues/450))
+  * Closed: Create new settings class to handle the settings data ([Issue #449](https://github.com/fpcorso/quiz_master_next/issues/449))
+  * Closed: Rewrite options system to allow for extendibility ([Issue #448](https://github.com/fpcorso/quiz_master_next/issues/448))
+  * Closed: Enable tabs for the admin results page ([Issue #408](https://github.com/fpcorso/quiz_master_next/issues/408))
+  * Closed: Create onboarding process ([Issue #397](https://github.com/fpcorso/quiz_master_next/issues/397))
+  * Closed: Create new contact tab to allow form creation ([Issue #394](https://github.com/fpcorso/quiz_master_next/issues/394))
+  * Closed: Move Certificate to free addon ([Issue #381](https://github.com/fpcorso/quiz_master_next/issues/381))
+  * Closed: Ability to add check box for privacy statement with the contact fields ([Issue #372](https://github.com/fpcorso/quiz_master_next/issues/372))
+  * Closed: Customize the "Please complete all required fields!" text ([Issue #371](https://github.com/fpcorso/quiz_master_next/issues/371))
+  * Closed: Allow admins to customize the validation error messages ([Issue #346](https://github.com/fpcorso/quiz_master_next/issues/346))
+  * Closed: Hint field cannot be customized ([Issue #262](https://github.com/fpcorso/quiz_master_next/issues/262))
+  * Closed: Add custom fields to the contact form ([Issue #211](https://github.com/fpcorso/quiz_master_next/issues/211))
+  * Closed: Scrollable List of Quizzes ([Issue #46](https://github.com/fpcorso/quiz_master_next/issues/46))
 
 = 4.7.10 (January 1, 2017) =
   * Closed Bug: Edit question not working when visual editor is off - Issue #497
@@ -121,4 +136,4 @@ This is usually a theme conflict. You can [checkout out our common conflict solu
 == Upgrade Notice ==
 
 = 5.0.0 =
-Upgrade to x
+Upgrade to use a variety of new features including new contact fields system, new options to customize hint and error messages, and more!


### PR DESCRIPTION
* Closed: Fix delete custom post types during uninstall bug ([Issue #527](https://github.com/fpcorso/quiz_master_next/issues/527))
* Closed: Change Shortcode To QSM ([Issue #515](https://github.com/fpcorso/quiz_master_next/issues/515))
* Closed: Search function for quizzes/surveys ([Issue #492](https://github.com/fpcorso/quiz_master_next/issues/492))
* Closed: Create new fields class to handle creation/post data of settings fields ([Issue #450](https://github.com/fpcorso/quiz_master_next/issues/450))
* Closed: Create new settings class to handle the settings data ([Issue #449](https://github.com/fpcorso/quiz_master_next/issues/449))
* Closed: Rewrite options system to allow for extendibility ([Issue #448](https://github.com/fpcorso/quiz_master_next/issues/448))
* Closed: Enable tabs for the admin results page ([Issue #408](https://github.com/fpcorso/quiz_master_next/issues/408))
* Closed: Create onboarding process ([Issue #397](https://github.com/fpcorso/quiz_master_next/issues/397))
* Closed: Create new contact tab to allow form creation ([Issue #394](https://github.com/fpcorso/quiz_master_next/issues/394))
* Closed: Move Certificate to free addon ([Issue #381](https://github.com/fpcorso/quiz_master_next/issues/381))
* Closed: Ability to add check box for privacy statement with the contact fields ([Issue #372](https://github.com/fpcorso/quiz_master_next/issues/372))
* Closed: Customize the "Please complete all required fields!" text ([Issue #371](https://github.com/fpcorso/quiz_master_next/issues/371))
* Closed: Allow admins to customize the validation error messages ([Issue #346](https://github.com/fpcorso/quiz_master_next/issues/346))
* Closed: Hint field cannot be customized ([Issue #262](https://github.com/fpcorso/quiz_master_next/issues/262))
* Closed: Add custom fields to the contact form ([Issue #211](https://github.com/fpcorso/quiz_master_next/issues/211))
* Closed: Scrollable List of Quizzes ([Issue #46](https://github.com/fpcorso/quiz_master_next/issues/46))