### PR TITLE
Add htmlentities() to fix dynamic insertion bug

### DIFF
--- a/php/question-types.php
+++ b/php/question-types.php
@@ -40,7 +40,7 @@ function qmn_multiple_choice_display($id, $question, $answers)
       if ($answer[0] != "")
       {
 				$question_display .= "<div class='qmn_mc_answer_wrap' id='question".$id."-".esc_attr($answer[0])."'>";
-        $question_display .= "<input type='radio' class='qmn_quiz_radio' name='question".$id."' id='question".$id."_".$mlw_answer_total."' value='".esc_attr($answer[0])."' /> <label for='question".$id."_".$mlw_answer_total."'>".htmlspecialchars_decode($answer[0], ENT_QUOTES)."</label>";
+        $question_display .= "<input type='radio' class='qmn_quiz_radio' name='question".$id."' id='question".$id."_".$mlw_answer_total."' value='".htmlentities(esc_attr($answer[0]))."' /> <label for='question".$id."_".$mlw_answer_total."'>".htmlspecialchars_decode($answer[0], ENT_QUOTES)."</label>";
 				$question_display .= "</div>";
       }
     }


### PR DESCRIPTION
Dynamic insertion of correct/incorrect classes for multiple choice answers doesn't work if the answer contains a ' or ". 

This works: He is barefoot
This doesn't work: He’s barefoot

Adding htmlentities to the radio button value fixes the issue.

(I'm still a fairly new contributor to OS projects, so apologies if I've done any of this wrong! Looking to learn and improve...)