### PR TITLE
[Fix] Improve validation for "fill in the blank"

### DIFF
--- a/php/question-types.php
+++ b/php/question-types.php
@@ -916,15 +916,17 @@ function qmn_fill_blank_review($id, $question, $answers)
 		$return_array['question_text'] = str_replace( "%BLANK%", "__________", do_shortcode(htmlspecialchars_decode($question, ENT_QUOTES)));
 	}
   if ( isset( $_POST["question".$id] ) ) {
-    $mlw_user_answer = strval( stripslashes( htmlspecialchars_decode( $_POST["question".$id], ENT_QUOTES ) ) );
+    $decode_user_answer = strval( stripslashes( htmlspecialchars_decode( $_POST["question".$id], ENT_QUOTES ) ) );
+    $mlw_user_answer = trim( preg_replace( '/\s\s+/', ' ', str_replace( "\n", " ", $decode_user_answer ) ) );
   } else {
     $mlw_user_answer = " ";
   }
   $return_array['user_text'] = $mlw_user_answer;
   foreach($answers as $answer)
   {
-    $return_array['correct_text'] = strval(htmlspecialchars_decode($answer[0], ENT_QUOTES));
-    if (strtoupper($return_array['user_text']) == strtoupper($return_array['correct_text']))
+    $decode_correct_text = strval(htmlspecialchars_decode($answer[0], ENT_QUOTES));
+    $return_array['correct_text'] = trim( preg_replace( '/\s\s+/', ' ', str_replace( "\n", " ", $decode_correct_text ) ) );
+    if (mb_strtoupper($return_array['user_text']) == mb_strtoupper($return_array['correct_text']))
     {
       $return_array['correct'] = "correct";
       $return_array['points'] = $answer[1];

--- a/php/question-types.php
+++ b/php/question-types.php
@@ -325,15 +325,17 @@ function qmn_small_open_review($id, $question, $answers)
     'correct_text' => ''
   );
   if ( isset( $_POST["question".$id] ) ) {
-    $mlw_user_answer = strval( stripslashes( htmlspecialchars_decode( $_POST["question".$id], ENT_QUOTES ) ) );
+    $decode_user_answer = strval( stripslashes( htmlspecialchars_decode( $_POST["question".$id], ENT_QUOTES ) ) );
+    $mlw_user_answer = trim( preg_replace( '/\s\s+/', ' ', str_replace( "\n", " ", $decode_user_answer ) ) );
   } else {
     $mlw_user_answer = " ";
   }
   $return_array['user_text'] = $mlw_user_answer;
   foreach($answers as $answer)
   {
-    $return_array['correct_text'] = strval(htmlspecialchars_decode($answer[0], ENT_QUOTES));
-    if (strtoupper($return_array['user_text']) == strtoupper($return_array['correct_text']))
+    $decode_correct_text = strval(htmlspecialchars_decode($answer[0], ENT_QUOTES));
+    $return_array['correct_text'] = trim( preg_replace( '/\s\s+/', ' ', str_replace( "\n", " ", $decode_correct_text ) ) );
+    if (mb_strtoupper($return_array['user_text']) == mb_strtoupper($return_array['correct_text']))
     {
       $return_array['correct'] = "correct";
       $return_array['points'] = $answer[1];
@@ -495,15 +497,17 @@ function qmn_large_open_review($id, $question, $answers)
     'correct_text' => ''
   );
   if ( isset( $_POST["question".$id] ) ) {
-    $mlw_user_answer = strval( stripslashes( htmlspecialchars_decode( $_POST["question".$id], ENT_QUOTES ) ) );
+    $decode_user_answer = strval( stripslashes( htmlspecialchars_decode( $_POST["question".$id], ENT_QUOTES ) ) );
+    $mlw_user_answer = trim( preg_replace( '/\s\s+/', ' ', str_replace( "\n", " ", $decode_user_answer ) ) );
   } else {
     $mlw_user_answer = " ";
   }
   $return_array['user_text'] = $mlw_user_answer;
   foreach($answers as $answer)
   {
-    $return_array['correct_text'] = strval(htmlspecialchars_decode($answer[0], ENT_QUOTES));
-    if (strtoupper($return_array['user_text']) == strtoupper($return_array['correct_text']))
+    $decode_correct_text = strval(htmlspecialchars_decode($answer[0], ENT_QUOTES));
+    $return_array['correct_text'] = trim( preg_replace( '/\s\s+/', ' ', str_replace( "\n", " ", $decode_correct_text ) ) );
+    if (mb_strtoupper($return_array['user_text']) == mb_strtoupper($return_array['correct_text']))
     {
       $return_array['correct'] = "correct";
       $return_array['points'] = $answer[1];


### PR DESCRIPTION
ISSUE:
On latest version available of quiz_master_next, if you try to validate text on other non-english language you face a validation error forcing correct answers to be added more than once. For example, if correct answer is "Atún", is necessary to add another correct answer all capitalized "ATÚN" in case user who fills the quiz use capital letters. This because to validate we transform text to uppercase letters, but this works well if you don't use special characters like "ü" or "á", and so on...

Also, when user who fills the quiz use autocorrect an extra whitespace is added and if is not deleted then answer is validated as FALSE.

SOLUTION:
1.- For uppercase letters validation replace "strtoupper" for "mb_strtoupper", that way all letters (no matter if special char or not) will be converted to uppercase.
2.- For whitespace, we need to decode the correct text and user text and then replace all white spaces: the ones added at the beginning and the end will be removed, and if more than one whitespace is added between 2 words will be replaced for only one whitespace.