### PR TITLE
fixed tinymce issues and default opened tab with active translations

### DIFF
--- a/js/qsm-admin-question.js
+++ b/js/qsm-admin-question.js
@@ -277,7 +277,9 @@ var QSMQuestion;
 			var questionText = QSMQuestion.prepareQuestionText( question.get( 'name' ) );
 			$( '#edit_question_id' ).val( questionID );
 			var question_editor = tinyMCE.get( 'question-text' );
-			if ( question_editor ) {
+			if ($('#wp-question-text-wrap').hasClass('html-active')) {
+				jQuery( "#question-text" ).val( questionText );
+			} else if ( question_editor ) {
 				tinyMCE.get( 'question-text' ).setContent( questionText );
 			} else {
 				jQuery( "#question-text" ).val( questionText );
@@ -328,6 +330,7 @@ var QSMQuestion;
 			var settings = {
 				mediaButtons: true,
 				tinymce:      {
+      				forced_root_block : '',
 					toolbar1: 'formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,strikethrough,hr,forecolor,pastetext,removeformat,codeformat,undo,redo'
 				},
 				quicktags:    true,

--- a/php/admin/addons-page.php
+++ b/php/admin/addons-page.php
@@ -14,7 +14,7 @@ function qmn_addons_page() {
 	}
 
 	global $mlwQuizMasterNext;
-	$active_tab = isset( $_GET[ 'tab' ] ) ? $_GET[ 'tab' ] : 'featured-addons';
+	$active_tab = strtolower(str_replace( " ", "-", isset( $_GET[ 'tab' ] ) ? $_GET[ 'tab' ] : __( "Featured Addons", 'quiz-master-next' )));
 	$tab_array = $mlwQuizMasterNext->pluginHelper->get_addon_tabs();
 	?>
 	<div class="wrap">

--- a/php/admin/admin-results-page.php
+++ b/php/admin/admin-results-page.php
@@ -16,7 +16,7 @@ function qsm_generate_admin_results_page() {
 
 	// Retrieves the current stab and all registered tabs
 	global $mlwQuizMasterNext;
-	$active_tab = isset( $_GET[ 'tab' ] ) ? $_GET[ 'tab' ] : 'quiz-results';
+	$active_tab = strtolower(str_replace( " ", "-", isset( $_GET[ 'tab' ] ) ? $_GET[ 'tab' ] : __( 'Quiz Results', 'quiz-master-next' )));
 	$tab_array = $mlwQuizMasterNext->pluginHelper->get_admin_results_tabs();
 
 	?>

--- a/php/admin/quiz-options-page.php
+++ b/php/admin/quiz-options-page.php
@@ -21,7 +21,7 @@ function qsm_generate_quiz_options() {
 
 	// Get registered tabs for the options page and set current tab
 	$tab_array = $mlwQuizMasterNext->pluginHelper->get_settings_tabs();
-	$active_tab = isset( $_GET[ 'tab' ] ) ? stripslashes( $_GET[ 'tab' ] ) : 'questions';
+	$active_tab = strtolower(str_replace( " ", "-", isset( $_GET[ 'tab' ] ) ? stripslashes( $_GET[ 'tab' ] ) : __( 'Questions', 'quiz-master-next' )));
 
 	// Prepares quiz.
 	$quiz_id = isset( $_GET['quiz_id'] ) ? intval( $_GET['quiz_id'] ) : 0;


### PR DESCRIPTION
1. Fixed: root paragraph tag was always added into a question during switching between tinymce editor and html editor
2. Fixed: question's html isn't updated in tinymce editor if html tab was active earlier
3. Fixed default opened tab with active translations