### PR TITLE
Fix undefined access at delete_question static function

### DIFF
--- a/php/classes/class-qsm-questions.php
+++ b/php/classes/class-qsm-questions.php
@@ -194,6 +194,8 @@ class QSM_Questions {
 	 * @return bool True if successful
 	 */
 	public static function delete_question( $question_id ) {
+		global $wpdb;
+		
 		$results = $wpdb->update(
 			$wpdb->prefix . 'mlw_questions',
 			array(


### PR DESCRIPTION
The delete_question method at QSM_Questions class was missing the `global $wpdb;` declaration, raising Exception when using it.